### PR TITLE
Add background service worker for chrome extension

### DIFF
--- a/extension/TESTING.md
+++ b/extension/TESTING.md
@@ -1,0 +1,109 @@
+# Testing the Service Worker
+
+To test, go to `chrome://extensions`, turn on Developer mode, load the unpacked
+extension folder, and click "Inspect views: service worker" to open DevTools.
+
+Paste these into the Console tab one at a time.
+
+---
+
+## Test 1 - Write and read back from storage
+
+```js
+await chrome.storage.local.set({
+  session: {
+    user: { name: 'Jane Doe', email: 'jane@example.com', resumeUrl: 'https://example.com/resume.pdf' },
+    applications: [],
+    settings: { autofillEnabled: true, notificationsEnabled: true },
+    lastInitialized: new Date().toISOString()
+  }
+});
+const result = await chrome.storage.local.get('session');
+console.log('READ-BACK:', result.session);
+// should print back the object with user.name = 'Jane Doe'
+```
+
+---
+
+## Test 2 - GET_USER_DATA message
+
+```js
+const response = await chrome.runtime.sendMessage({
+  action: 'GET_USER_DATA',
+  payload: {}
+});
+console.log('GET_USER_DATA response:', response);
+// should return { success: true, data: { name: 'Jane Doe', ... } }
+```
+
+---
+
+## Test 3 - SAVE_SESSION message
+
+```js
+const response = await chrome.runtime.sendMessage({
+  action: 'SAVE_SESSION',
+  payload: { user: { name: 'John Smith', email: 'john@example.com' } }
+});
+console.log('SAVE_SESSION response:', response);
+// should return { success: true, data: { user: { name: 'John Smith', ... }, ... } }
+```
+
+---
+
+## Test 4 - Add an application and list them
+
+```js
+const addResp = await chrome.runtime.sendMessage({
+  action: 'ADD_APPLICATION',
+  payload: { company: 'Acme Corp', role: 'Frontend Engineer', status: 'applied' }
+});
+console.log('ADD_APPLICATION:', addResp);
+
+const listResp = await chrome.runtime.sendMessage({
+  action: 'GET_APPLICATIONS',
+  payload: {}
+});
+console.log('GET_APPLICATIONS:', listResp);
+// the added app should have an auto-generated id, and the list should have at least 1 entry
+```
+
+---
+
+## Test 5 - Check that storage.onChanged fires
+
+```js
+await chrome.storage.local.set({ debugPing: Date.now() });
+// look in the console for the "[background] storage.onChanged" log group
+```
+
+---
+
+## Test 6 - Worker re-init after Terminate
+
+1. Go to `chrome://extensions` and click "Terminate" under the service worker
+2. Run the command below - Chrome will restart the worker automatically
+3. Check the console for the `[background] onInstalled` log to confirm it came back up
+4. Data from before should still be there since initializeDefaultSession doesn't overwrite existing stuff
+
+```js
+const response = await chrome.runtime.sendMessage({
+  action: 'GET_SESSION',
+  payload: {}
+});
+console.log('POST-TERMINATE GET_SESSION:', response);
+// should still have all the data from earlier tests
+```
+
+---
+
+## Test 7 - Bad action returns an error
+
+```js
+const response = await chrome.runtime.sendMessage({
+  action: 'DOES_NOT_EXIST',
+  payload: {}
+});
+console.log('UNKNOWN ACTION:', response);
+// should return { success: false, error: 'Unknown action: DOES_NOT_EXIST' }
+```

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,180 @@
+// background.js - service worker for the job application tracker extension
+// MV3 service workers can get killed at any time, so nothing is stored
+// in global variables. Everything goes through chrome.storage instead.
+
+// default structure for a fresh session
+const DEFAULT_SESSION = {
+  user: null,
+  applications: [],
+  settings: {
+    autofillEnabled: true,
+    notificationsEnabled: true,
+  },
+  lastInitialized: null,
+};
+
+// quick wrappers so I don't have to type chrome.storage._____ everywhere
+function getLocal(keys) {
+  return chrome.storage.local.get(keys);
+}
+
+function setLocal(data) {
+  return chrome.storage.local.set(data);
+}
+
+function getSession(keys) {
+  return chrome.storage.session.get(keys);
+}
+
+function setSession(data) {
+  return chrome.storage.session.set(data);
+}
+
+// sets up storage with defaults if nothing exists yet.
+// if there's already data saved, it keeps it and just fills in any missing fields.
+async function initializeDefaultSession() {
+  const existing = await getLocal(['session']);
+  const session = existing.session || {};
+
+  const merged = {
+    user: session.user ?? DEFAULT_SESSION.user,
+    applications: session.applications ?? DEFAULT_SESSION.applications,
+    settings: {
+      ...DEFAULT_SESSION.settings,
+      ...(session.settings || {}),
+    },
+    lastInitialized: new Date().toISOString(),
+  };
+
+  await setLocal({ session: merged });
+
+  // let the popup know the worker is running
+  await setSession({ workerAlive: true });
+
+  console.log('[background] Session initialized:', merged);
+  return merged;
+}
+
+// runs when the extension is first installed or updated
+chrome.runtime.onInstalled.addListener(async (details) => {
+  console.log(`[background] onInstalled - reason: ${details.reason}`);
+  await initializeDefaultSession();
+});
+
+// runs every time the browser starts up
+chrome.runtime.onStartup.addListener(async () => {
+  console.log('[background] onStartup - browser launched');
+  await initializeDefaultSession();
+});
+
+// main message listener - the popup and content scripts send messages here
+// and this routes them to the right handler
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  const { action, payload } = message;
+
+  console.log(`[background] Message received - action: ${action}`, payload);
+
+  // need to return true here so the response channel stays open while
+  // the async stuff finishes
+  handleMessage(action, payload, sender)
+    .then((result) => sendResponse({ success: true, data: result }))
+    .catch((err) => {
+      console.error(`[background] Error handling "${action}":`, err);
+      sendResponse({ success: false, error: err.message });
+    });
+
+  return true;
+});
+
+// routes each action to the right logic. every case pulls fresh data
+// from storage so we don't rely on stale globals.
+async function handleMessage(action, payload, _sender) {
+  switch (action) {
+
+    case 'SAVE_SESSION': {
+      const { session: current } = await getLocal(['session']);
+      const updated = { ...current, ...payload };
+      await setLocal({ session: updated });
+      return updated;
+    }
+
+    case 'GET_SESSION': {
+      const { session } = await getLocal(['session']);
+      return session ?? DEFAULT_SESSION;
+    }
+
+    case 'GET_USER_DATA': {
+      const { session } = await getLocal(['session']);
+      return session?.user ?? null;
+    }
+
+    case 'SET_USER_DATA': {
+      const { session } = await getLocal(['session']);
+      session.user = { ...session.user, ...payload };
+      await setLocal({ session });
+      return session.user;
+    }
+
+    case 'ADD_APPLICATION': {
+      const { session } = await getLocal(['session']);
+      const app = {
+        id: crypto.randomUUID(),
+        ...payload,
+        appliedAt: new Date().toISOString(),
+      };
+      session.applications = [...(session.applications || []), app];
+      await setLocal({ session });
+      return app;
+    }
+
+    case 'GET_APPLICATIONS': {
+      const { session } = await getLocal(['session']);
+      return session?.applications ?? [];
+    }
+
+    case 'UPDATE_APPLICATION': {
+      const { session } = await getLocal(['session']);
+      const idx = session.applications.findIndex((a) => a.id === payload.id);
+      if (idx === -1) throw new Error(`Application ${payload.id} not found`);
+      session.applications[idx] = { ...session.applications[idx], ...payload };
+      await setLocal({ session });
+      return session.applications[idx];
+    }
+
+    case 'DELETE_APPLICATION': {
+      const { session } = await getLocal(['session']);
+      session.applications = session.applications.filter(
+        (a) => a.id !== payload.id,
+      );
+      await setLocal({ session });
+      return { deleted: payload.id };
+    }
+
+    case 'GET_SETTINGS': {
+      const { session } = await getLocal(['session']);
+      return session?.settings ?? DEFAULT_SESSION.settings;
+    }
+
+    case 'UPDATE_SETTINGS': {
+      const { session } = await getLocal(['session']);
+      session.settings = { ...session.settings, ...payload };
+      await setLocal({ session });
+      return session.settings;
+    }
+
+    default:
+      throw new Error(`Unknown action: ${action}`);
+  }
+}
+
+// logs any storage changes to the console - useful for debugging to make sure
+// the popup and content scripts are staying in sync
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  console.group(`[background] storage.onChanged - area: ${areaName}`);
+  for (const [key, { oldValue, newValue }] of Object.entries(changes)) {
+    console.log(`  key: "${key}"`);
+    console.log('    old:', oldValue);
+    console.log('    new:', newValue);
+  }
+  console.groupEnd();
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 3,
+  "name": "Job Application Tool",
+  "version": "1.0.0",
+  "description": "Track and manage job applications directly from your browser.",
+  "permissions": ["storage"],
+  "background": {
+    "service_worker": "background.js"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `extension/` directory with a Manifest V3 background service worker (`background.js`), `manifest.json`, and `TESTING.md`
- The service worker manages user session state, routes messages from the popup/content scripts, and logs storage changes for debugging
- Fully stateless design — all data is read from `chrome.storage` inside each listener so the worker handles suspend/terminate correctly

## Notes
- The existing popup components in `frontend/src/extension/` use `chrome.storage.local` with the key `user_profile`. This service worker uses a separate `session` key. They don't conflict, but we should align them as the extension comes together.
- `TESTING.md` has copy-paste console commands to verify everything in the service worker DevTools

## Test plan
- [ ] Load unpacked extension from `extension/` folder in `chrome://extensions`
- [ ] Inspect the service worker and run through the tests in `TESTING.md`
- [ ] Verify storage read/write, message routing, and re-init after Terminate