### PR TITLE
Address Mapping Issues Fixed

### DIFF
--- a/backend/application_runner.py
+++ b/backend/application_runner.py
@@ -121,7 +121,7 @@ def _selector_to_by(selector: str):
 
 PROFILE_FIELD_NAMES = [
     "firstname", "lastname", "first_name", "last_name", "email", "phone",
-    "address", "city", "state", "postal", "zip", "resume", "cv",
+    "address_line_1", "address_line_2", "city", "state", "postal", "zip", "resume", "cv",
 ]
 
 # Generic button semantics: classify by visible text only (works for any ATS).

--- a/backend/llm_mapping_service.py
+++ b/backend/llm_mapping_service.py
@@ -391,14 +391,20 @@ class FormInteractionEngine:
         if ("referral" in name or "referred" in name or "referral" in label or "referred" in label) and "who" not in label and "indicate" not in label:
             v = profile.get("referred_by_employee") or profile.get("referred_by_recruiting_agency")
             return "Yes" if v and str(v).lower() in ("yes", "true", "1") else "No"
-        if "address" in name or label in ("address", "location"):
-            return (profile.get("address") or "").strip()
+        if "email" in name or "email" in label:
+            return (profile.get("email") or "").strip()
         if "city" in name or "city" in label:
             return (profile.get("city") or "").strip()
         if "state" in name or "state" in label:
             return (profile.get("state") or "").strip()
         if "postal" in name or "zip" in name or "postal" in label or "zip" in label:
             return (profile.get("zip_code") or profile.get("postal_code") or "").strip()
+        if "address" in name or label in ("address", "location"):
+            # Check if address line 2, suite, apartment, or unit
+            if any(x in name or x in label for x in ["2", "line2", "apt", "suite", "unit"]):
+                return (profile.get("address_line_2") or "").strip()
+            # otherwise return regular address
+            return (profile.get("address_line_1") or profile.get("address") or "").strip()
         if "signature" in name and "disability" in name:
             fn = (profile.get("first_name") or "").strip()
             ln = (profile.get("last_name") or "").strip()

--- a/backend/profile.json.template
+++ b/backend/profile.json.template
@@ -4,9 +4,10 @@
     "last_name": "",
     "email": "",
     "phone": "",
-    "address": "",
+    "address_line_1": "",
+    "address_line_2": "",
     "city": "",
-    "state": "",
+    "state": ""
     "zip_code": "",
     "country": "",
     "resume_path": "",

--- a/backend/tests/test_heuristic_matcher.py
+++ b/backend/tests/test_heuristic_matcher.py
@@ -10,6 +10,8 @@ class HeuristicMatcher:
             "last_name": ["last name", "surname", "family name", "lname", "lastname"],
             "email": ["email", "e-mail address", "email address", "emailaddress"],
             "phone": ["phone", "mobile", "cell", "contact number", "phonenumber"],
+            "address_line_1": ["address line 1", "street address", "address 1", "mailing address", "address"],
+            "address_line_2": ["address line 2", "address 2", "apt", "suite", "unit", "ste", "apartment"],
             "resume": ["resume", "cv", "curriculum vitae", "upload resume"]
         }
 
@@ -43,6 +45,19 @@ class HeuristicMatcher:
                 if score > highest_score:
                     highest_score = score
                     best_field = standard_key
+
+        # stop address_line_1 from dominating all the location fills due to heuristic matching "address" with every address field
+        if best_field == "address_line_1":
+            # if supposed to be city:
+            if "city" in search_blob:
+                best_field = "city"
+            # if supposed to be zip-code:
+            if any(x in search_blob for x in ["zip-code", "zipcode", "zip", "postal"]):
+                best_field = "zip_code"
+            # if supposed to be address line 2
+            if any(x in search_blob for x in ["address 2", "apt", "suite", "unit", "ste", "apartment"]):
+                # overrule previous guess and make it actually address 2
+                best_field = "address_line_2"
 
         # only return the key if confidence threshold is high enough
         return best_field if highest_score > 0.6 else "unknown"


### PR DESCRIPTION
I came across an issue where if there was a second address line (for unit, apartment, etc.) then it would take the first street address and duplicate it into address line 2. It also did this in some email forms, as the "address" in "email address" tags would trigger the sreet address to fill in for the email address. 

I did this by having the _value_from_rules logic in the LLM mapper prioritize more sensitive values like "email", "city", "state", "postal", before it would snatch the street address accidentally for those values. I also made the heuristics matcher check for any address #2 line (suite, apartment, unit) values in case it tries to put the street address into the address 2 spot. I also and adding address_line_1 and address_line_2 to the heuristics matcher program. I also added those separate address line 1 and 2 values to profile.json.template, instead of just one address line.