### PR TITLE
Fix: update name mapping to include id and placeholder attributes

### DIFF
--- a/backend/llm_mapping_service.py
+++ b/backend/llm_mapping_service.py
@@ -359,10 +359,8 @@ class FormInteractionEngine:
                     label = " ".join(keywords)
                     break
         if "first" in name and "name" in name or "first name" in label or "first" in placeholder and "name" in placeholder or "first" in id_attr and "name" in id_attr:
-            print(f"!!!!!!!!!!!!!!!!!!!!! first in name and name in name or first name in label: {profile.get("first_name")}")
             return (profile.get("first_name") or "").strip()
         if "last" in name and "name" in name or "last name" in label or "last" in placeholder and "name" in placeholder or "last" in id_attr and "name" in id_attr:
-            print(f"!!!!!!!!!!!!!!!!!!!!! last in name and name in name or last name in label: {profile.get("last_name")}")
             return (profile.get("last_name") or "").strip()
         # Work eligibility (eligible to work in the US) -> Yes when work_authorization present
         eligible_key = "eligible" in label or "eligible" in name or "eligibility" in label or "eligibility" in name

--- a/backend/llm_mapping_service.py
+++ b/backend/llm_mapping_service.py
@@ -359,11 +359,13 @@ class FormInteractionEngine:
                     label = " ".join(keywords)
                     break
         if "first" in name and "name" in name or "first name" in label or "first" in placeholder and "name" in placeholder or "first" in id_attr and "name" in id_attr:
-            print(f"!!!!!!!!!!!!!!!!!!!!! first in name and name in name or first name in label: {profile.get("first_name")}")
             return (profile.get("first_name") or "").strip()
         if "last" in name and "name" in name or "last name" in label or "last" in placeholder and "name" in placeholder or "last" in id_attr and "name" in id_attr:
-            print(f"!!!!!!!!!!!!!!!!!!!!! last in name and name in name or last name in label: {profile.get("last_name")}")
             return (profile.get("last_name") or "").strip()
+        # Preferred name
+        if ("preferred" in name and "name" in name) or ("known" in name and "as" in name) or "preferred name" in label or ("preferred" in placeholder and "name" in placeholder) or ("preferred" in id_attr and "name" in id_attr) or ("known" in id_attr and "as" in id_attr):
+            pname = (profile.get("preferred_name") or "").strip()
+            return pname if pname else None
         # Work eligibility (eligible to work in the US) -> Yes when work_authorization present
         eligible_key = "eligible" in label or "eligible" in name or "eligibility" in label or "eligibility" in name
         work_key = "work" in label or "work" in name or "authorization" in label or "authorization" in name

--- a/backend/llm_mapping_service.py
+++ b/backend/llm_mapping_service.py
@@ -339,6 +339,9 @@ class FormInteractionEngine:
     def _value_from_rules(self, meta: Dict, profile: Dict) -> Optional[str]:
         label = (meta.get("label_text") or "").lower()
         name = (meta.get("name") or "").lower()
+        id_attr = (meta.get("id") or "").lower()
+        placeholder = (meta.get("placeholder") or "").lower()
+
         # Refresh label for any field with empty label (helps rules + LLM get question text)
         if not label:
             label = (self._refresh_label_if_empty(meta) or "").lower()
@@ -355,9 +358,11 @@ class FormInteractionEngine:
                 if q_id == kid:
                     label = " ".join(keywords)
                     break
-        if "first" in name and "name" in name or "first name" in label:
+        if "first" in name and "name" in name or "first name" in label or "first" in placeholder and "name" in placeholder or "first" in id_attr and "name" in id_attr:
+            print(f"!!!!!!!!!!!!!!!!!!!!! first in name and name in name or first name in label: {profile.get("first_name")}")
             return (profile.get("first_name") or "").strip()
-        if "last" in name and "name" in name or "last name" in label:
+        if "last" in name and "name" in name or "last name" in label or "last" in placeholder and "name" in placeholder or "last" in id_attr and "name" in id_attr:
+            print(f"!!!!!!!!!!!!!!!!!!!!! last in name and name in name or last name in label: {profile.get("last_name")}")
             return (profile.get("last_name") or "").strip()
         # Work eligibility (eligible to work in the US) -> Yes when work_authorization present
         eligible_key = "eligible" in label or "eligible" in name or "eligibility" in label or "eligibility" in name

--- a/backend/profile.json.template
+++ b/backend/profile.json.template
@@ -2,6 +2,7 @@
   "applicant_info": {
     "first_name": "",
     "last_name": "",
+    "preferred_name": "",
     "email": "",
     "phone": "",
     "address_line_1": "",

--- a/backend/tests/test_heuristic_matcher.py
+++ b/backend/tests/test_heuristic_matcher.py
@@ -8,10 +8,11 @@ class HeuristicMatcher:
         self.standard_fields = {
             "first_name": ["first name", "given name", "fname", "first", "firstname"],
             "last_name": ["last name", "surname", "family name", "lname", "lastname"],
+            "preferred_name": ["preferred name", "known as", "also known as"],
             "email": ["email", "e-mail address", "email address", "emailaddress"],
             "phone": ["phone", "mobile", "cell", "contact number", "phonenumber"],
-            "address_line_1": ["address line 1", "street address", "address 1", "mailing address", "address"],
-            "address_line_2": ["address line 2", "address 2", "apt", "suite", "unit", "ste", "apartment"],
+            "address_line_1": ["address line 1", "street address", "address 1", "mailing address"],
+            "address_line_2": ["address line 2", "address 2", "apt", "suite", "unit", "ste", "apartment", "building", "flat", "room", "floor", "bldg"],
             "resume": ["resume", "cv", "curriculum vitae", "upload resume"]
         }
 
@@ -58,6 +59,9 @@ class HeuristicMatcher:
             if any(x in search_blob for x in ["address 2", "apt", "suite", "unit", "ste", "apartment"]):
                 # overrule previous guess and make it actually address 2
                 best_field = "address_line_2"
+            # if address line 3 or higher, don't match
+            if any(x in search_blob for x in ["line 3", "line 4", "line 5"]):
+                best_field = "unknown"
 
         # only return the key if confidence threshold is high enough
         return best_field if highest_score > 0.6 else "unknown"

--- a/frontend/src/UploadPage.tsx
+++ b/frontend/src/UploadPage.tsx
@@ -8,9 +8,11 @@ const SAMPLE_PARSED_DATA: ProfileData = {
     applicant_info: {
         first_name: "Alex",
         last_name: "Johnson",
+        preferred_name: "",
         email: "alex.johnson@example.com",
         phone: "+1-415-555-2478",
-        address: "",
+        address_line_1: "",
+        address_line_2: "",
         city: "San Francisco",
         state: "CA",
         zip_code: "",

--- a/frontend/src/components/CandidateDetailsForm.tsx
+++ b/frontend/src/components/CandidateDetailsForm.tsx
@@ -24,7 +24,7 @@ function CandidateDetailsForm({ initialData, onSubmit }: CandidateDetailsFormPro
 
     // Check top-level fields
     const topLevelFields = [
-      'first_name', 'last_name', 'email', 'phone', 'address', 'city', 'state',
+      'first_name', 'last_name','preferred_name', 'email', 'phone', 'address_line_1', "address_line_2", 'city', 'state',
       'zip_code', 'country', 'linkedin_url', 'portfolio_url', 'years_of_experience',
       'education_level', 'college_name', 'salary_expectation', 'willing_to_relocate',
       'availability_date', 'work_authorization', 'gender', 'race_ethnicity', 'race',
@@ -123,6 +123,15 @@ function CandidateDetailsForm({ initialData, onSubmit }: CandidateDetailsFormPro
               required
             />
           </div>
+          <div className={`form-group ${isUnknown('preferred_name') ? 'unknown' : ''}`}>
+            <label htmlFor="preferred_name">Preferred Name *</label>
+            <input
+              id="preferred_name"
+              type="text"
+              value={v(info.preferred_name)}
+              onChange={(e) => handleChange('preferred_name', e.target.value)}
+            />
+          </div>
           <div className={`form-group ${isUnknown('email') ? 'unknown' : ''}`}>
             <label htmlFor="email">Email *</label>
             <input
@@ -149,13 +158,22 @@ value={v(info.phone)}
       <section className="form-section">
         <h2>Address</h2>
         <div className="form-grid">
-          <div className={`form-group full-width ${isUnknown('address') ? 'unknown' : ''}`}>
-            <label htmlFor="address">Street Address</label>
+          <div className={`form-group full-width ${isUnknown('address_line_1') ? 'unknown' : ''}`}>
+            <label htmlFor="address_line_1">Street Address</label>
             <input
-              id="address"
+              id="address_line_1"
               type="text"
-value={v(info.address)}
-            onChange={(e) => handleChange('address', e.target.value)}
+value={v(info.address_line_1)}
+              onChange={(e) => handleChange('address_line_1', e.target.value)}
+            />
+          </div>
+          <div className={`form-group full-width ${isUnknown('address_line_2') ? 'unknown' : ''}`}>
+            <label htmlFor="address_line_2">Street Address Line 2</label>
+            <input
+              id="address_line_2"
+              type="text"
+value={v(info.address_line_2)}
+              onChange={(e) => handleChange('address_line_2', e.target.value)}
             />
           </div>
           <div className={`form-group ${isUnknown('city') ? 'unknown' : ''}`}>

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -36,9 +36,11 @@ export interface TechnicalExperience {
 export interface ApplicantInfo {
   first_name: string;
   last_name: string;
+  preferred_name?: string;
   email: string;
   phone: string;
-  address: string;
+  address_line_1: string;
+  address_line_2?: string;
   city: string;
   state: string;
   zip_code: string;
@@ -74,9 +76,11 @@ export const createEmptyProfile = (): ProfileData => ({
   applicant_info: {
     first_name: "",
     last_name: "",
+    preferred_name: "",
     email: "",
     phone: "",
-    address: "",
+    address_line_1: "",
+    address_line_2: "",
     city: "",
     state: "",
     zip_code: "",


### PR DESCRIPTION
Came across a bug testing on this site: https://demoqa.com/automation-practice-form where if a first name and last name box only had placeholder and id attributes, and those values were encapsulated within an id called "userName_label", then value_from_rules would fill the users last name in both the first name and last name boxes. I fixed this by having it check for placeholder and id attributes, so it wouldn't miss the users first and last name even if they were hidden beneath some other "name" label. 