### PR TITLE
feat: advanced extension lifecycle and state management (#37)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -30,6 +30,161 @@ function setSession(data) {
   return chrome.storage.session.set(data);
 }
 
+// ============================================================
+// URL-Based Pre-fetching (Issue #37)
+// ============================================================
+
+const JOB_BOARD_PATTERNS = [
+  { name: 'linkedin',   pattern: /linkedin\.com\/jobs/i },
+  { name: 'indeed',     pattern: /indeed\.com/i },
+  { name: 'workday',    pattern: /myworkdayjobs\.com/i },
+  { name: 'greenhouse', pattern: /greenhouse\.io/i },
+  { name: 'lever',      pattern: /jobs\.lever\.co/i },
+];
+
+function detectJobBoard(url) {
+  if (!url) return null;
+  for (const board of JOB_BOARD_PATTERNS) {
+    if (board.pattern.test(url)) return board.name;
+  }
+  return null;
+}
+
+async function prefetchProfileForJobBoard(tabId, url) {
+  const board = detectJobBoard(url);
+  if (!board) return;
+
+  const { session } = await getLocal(['session']);
+  const profile = session?.user ?? null;
+
+  if (!profile) {
+    console.log(`[background] Pre-fetch skipped for ${board} - no user profile stored`);
+    return;
+  }
+
+  await setSession({
+    prefetchedProfile: {
+      board,
+      profile,
+      fetchedAt: new Date().toISOString(),
+    },
+  });
+
+  console.log(`[background] Profile pre-fetched for ${board} (tab ${tabId})`);
+}
+
+// changeInfo.url is only present when the URL itself changes, which is exactly
+// when we want to kick off a pre-fetch rather than on every load event.
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, _tab) => {
+  const url = changeInfo.url;
+  if (!url) return;
+  prefetchProfileForJobBoard(tabId, url).catch((err) => {
+    console.error('[background] prefetchProfileForJobBoard error:', err);
+  });
+});
+
+// ============================================================
+// Session Heartbeat (Issue #37)
+// ============================================================
+
+const HEARTBEAT_ALARM_NAME = 'SESSION_HEARTBEAT';
+const HEARTBEAT_INTERVAL_MINUTES = 3;
+// attempt a refresh if the token expires within this window
+const SESSION_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+async function initializeHeartbeatAlarm() {
+  const existing = await chrome.alarms.get(HEARTBEAT_ALARM_NAME);
+  if (existing) return;
+  chrome.alarms.create(HEARTBEAT_ALARM_NAME, {
+    delayInMinutes: HEARTBEAT_INTERVAL_MINUTES,
+    periodInMinutes: HEARTBEAT_INTERVAL_MINUTES,
+  });
+  console.log(`[background] Heartbeat alarm registered - interval: ${HEARTBEAT_INTERVAL_MINUTES}min`);
+}
+
+async function attemptTokenRefresh(user) {
+  try {
+    // replace this block with a real fetch() to your auth refresh endpoint:
+    // const res = await fetch('http://localhost:8000/api/auth/refresh', {
+    //   method: 'POST',
+    //   headers: { 'Content-Type': 'application/json' },
+    //   body: JSON.stringify({ refreshToken: user.refreshToken }),
+    // });
+    console.log('[background] Token refresh attempted for:', user.email ?? 'unknown');
+    await logError({
+      source: 'heartbeat',
+      message: 'Token refresh triggered - session was near expiry',
+      context: { email: user.email, tokenExpiresAt: user.tokenExpiresAt },
+    });
+  } catch (err) {
+    console.error('[background] Token refresh failed:', err);
+    await logError({ source: 'heartbeat', message: err.message, stack: err.stack });
+  }
+}
+
+async function runHeartbeat() {
+  console.log('[background] Heartbeat tick');
+
+  const { session } = await getLocal(['session']);
+  const user = session?.user ?? null;
+
+  if (!user) {
+    console.log('[background] Heartbeat - no authenticated user, skipping auth check');
+    await setSession({ lastHeartbeat: new Date().toISOString() });
+    return;
+  }
+
+  const tokenExpiry = user.tokenExpiresAt ? new Date(user.tokenExpiresAt).getTime() : null;
+  const now = Date.now();
+
+  if (tokenExpiry !== null && tokenExpiry - now < SESSION_EXPIRY_BUFFER_MS) {
+    console.warn('[background] Heartbeat - session nearing expiry, attempting refresh');
+    await attemptTokenRefresh(user);
+  } else {
+    console.log('[background] Heartbeat - session healthy');
+  }
+
+  await setSession({ lastHeartbeat: new Date().toISOString() });
+}
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === HEARTBEAT_ALARM_NAME) {
+    runHeartbeat().catch((err) => {
+      console.error('[background] Heartbeat error:', err);
+    });
+  }
+});
+
+// ============================================================
+// Centralized Error Logging (Issue #37)
+// ============================================================
+
+const MAX_ERROR_LOG_SIZE = 50;
+
+async function logError({ source = 'unknown', message = '', stack = null, context = null }) {
+  const { errorLog = [] } = await getLocal(['errorLog']);
+
+  const entry = {
+    id: crypto.randomUUID(),
+    timestamp: new Date().toISOString(),
+    source,
+    message,
+    stack,
+    context,
+  };
+
+  // newest entries at the front; cap the log so storage doesn't grow unbounded
+  const updated = [entry, ...errorLog].slice(0, MAX_ERROR_LOG_SIZE);
+  await setLocal({ errorLog: updated });
+
+  console.warn(`[background] Error logged from "${source}":`, message);
+  return entry;
+}
+
+// ============================================================
+// Core lifecycle
+// ============================================================
+
 // sets up storage with defaults if nothing exists yet.
 // if there's already data saved, it keeps it and just fills in any missing fields.
 async function initializeDefaultSession() {
@@ -50,6 +205,8 @@ async function initializeDefaultSession() {
 
   // let the popup know the worker is running
   await setSession({ workerAlive: true });
+
+  await initializeHeartbeatAlarm();
 
   console.log('[background] Session initialized:', merged);
   return merged;
@@ -160,6 +317,26 @@ async function handleMessage(action, payload, _sender) {
       session.settings = { ...session.settings, ...payload };
       await setLocal({ session });
       return session.settings;
+    }
+
+    case 'LOG_ERROR': {
+      const entry = await logError({
+        source: payload?.source ?? _sender?.url ?? 'unknown',
+        message: payload?.message ?? 'No message provided',
+        stack: payload?.stack ?? null,
+        context: payload?.context ?? null,
+      });
+      return entry;
+    }
+
+    case 'GET_ERROR_LOG': {
+      const { errorLog = [] } = await getLocal(['errorLog']);
+      return errorLog;
+    }
+
+    case 'CLEAR_ERROR_LOG': {
+      await setLocal({ errorLog: [] });
+      return { cleared: true };
     }
 
     default:


### PR DESCRIPTION
## Summary

Part of #37. Adds three proactive resilience features to the MV3 background service worker (`extension/background.js`):

- **URL-based pre-fetching** - `chrome.tabs.onUpdated` detects navigation to LinkedIn, Indeed, Workday, Greenhouse, and Lever, then loads the stored user profile into `chrome.storage.session` before the popup is opened
- **Session heartbeat** - a `chrome.alarms` alarm fires every 3 minutes to check token expiry; if the token expires within 5 minutes it calls `attemptTokenRefresh()` (stub ready to wire to `/api/auth/refresh`)
- **Centralized error logging** - a `LOG_ERROR` message action collects structured error entries from content scripts and the popup into `chrome.storage.local`, capped at 50 entries; `GET_ERROR_LOG` and `CLEAR_ERROR_LOG` companion actions also added

All state is stored in `chrome.storage` so nothing is lost when Chrome kills and restarts the service worker.

## Test plan

- [ ] Load the extension, navigate to a LinkedIn Jobs URL, inspect `chrome.storage.session` for `prefetchedProfile` entry
- [ ] Navigate to a non-job-board URL and confirm `prefetchedProfile` is not written
- [ ] Wait 3 minutes and confirm heartbeat tick appears in service worker console
- [ ] Set `tokenExpiresAt` to a time within 5 minutes in `session.user` and confirm refresh attempt is logged
- [ ] Send `{ action: 'LOG_ERROR', payload: { source: 'content', message: 'test' } }` from a content script and confirm the entry appears via `GET_ERROR_LOG`
- [ ] Confirm existing actions (GET_SESSION, ADD_APPLICATION, etc.) are unaffected