### PR TITLE
fix: wire create profile button to handler

### DIFF
--- a/frontend/src/extension/components/ProfileEditorPopup.tsx
+++ b/frontend/src/extension/components/ProfileEditorPopup.tsx
@@ -118,7 +118,7 @@ export function ProfileEditorPopup() {
         <div className="popup-empty">
           <h3>No Profile Yet</h3>
           <p>Upload your resume to get started, or fill in your details manually.</p>
-          <button className="popup-empty-button" onClick={() => window.open('http://localhost:5173/', '_blank')}>
+          <button type="button" className="popup-empty-button" onClick={handleCreateProfile}>
             Create Profile
           </button>
         </div>


### PR DESCRIPTION
Fixes the lint error CI surfaced after #53. Create Profile button was opening localhost in a new tab instead of calling `handleCreateProfile`.