### PR TITLE
fix: candidate details gray screen when upload returns partial data

### DIFF
--- a/backend/resume_parser.py
+++ b/backend/resume_parser.py
@@ -45,10 +45,11 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        "https://job-application-tool.vercel.app", # Railway app
+        "https://job-application-tool.vercel.app",
         "http://localhost:5173", "http://localhost:3000", "http://localhost:8080",
         "http://127.0.0.1:5173", "http://127.0.0.1:3000", "http://127.0.0.1:8080",
     ],
+    allow_origin_regex=r"https://frontend-.*\.vercel\.app",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/src/CandidateDetailsPage.tsx
+++ b/frontend/src/CandidateDetailsPage.tsx
@@ -15,7 +15,17 @@ function CandidateDetailsPage() {
   useEffect(() => {
     const stateData = location.state?.profileData as ProfileData | undefined;
     if (stateData) {
-      setParsedData(stateData);
+      const empty = createEmptyProfile();
+      const info = stateData.applicant_info;
+      setParsedData({
+        applicant_info: {
+          ...empty.applicant_info,
+          ...info,
+          work_experience: { ...empty.applicant_info.work_experience, ...info.work_experience },
+          technical_experience: { ...empty.applicant_info.technical_experience, ...info.technical_experience },
+          education: { ...empty.applicant_info.education, ...info.education },
+        },
+      });
       return;
     }
     getProfile()


### PR DESCRIPTION
Fixes a frontend crash where uploading a resume with fewer than 3 jobs or where OpenAI omits work_experience/technical_experience/education caused the candidate details page to gray out.

The form's useEffect iterates over hardcoded keys (job_1, job_2, job_3, skill_1..5) and calls Object.keys() on each, which throws TypeError when the parsed data is missing those keys.

This applies the same defensive merge with createEmptyProfile() that already exists for the getProfile() path, but for the location.state.profileData path (the path taken right after upload).

## Test plan
- Open the Vercel preview URL for this branch
- Upload a resume with 1 or 2 jobs (not 3)
- Confirm the candidate details page renders without going gray